### PR TITLE
🎉 Add write guard

### DIFF
--- a/demo/app/App_Resources/Android/app.gradle
+++ b/demo/app/App_Resources/Android/app.gradle
@@ -8,7 +8,7 @@
 android {  
   defaultConfig {  
     generatedDensities = []
-    applicationId = "org.nativescript.plugindemo.nfc"  
+    applicationId = "com.nordsense.nativescript.plugindemo.nfc"  
   }  
   aaptOptions {  
     additionalParameters "--no-version-vectors"  

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -83,15 +83,28 @@ export class HelloWorldModel extends observable.Observable {
         textRecords: [
           {
             id: [1],
-            text: "Hello!!!!!",
+            text: "This is awesome!",
           },
         ],
-        startMessage: "Hold near writable NFC tag to write.",
-        endMessage: "Command sent!",
+        startMessage: "Approach an NFC Tag",
+        endMessage: "Done!",
+        writeGuardBeforeCheckErrorMessage: "Write guard (before) says No!",
+        writeGuardAfterCheckDelay: 5000,
+        writeGuardAfterCheckErrorMessage: "Write guard (after) says No!",
+        writeGuardAfterCheckMessage: "Almost done, please do not remove the tag!"
+      }, (data) => {
+        return true;
+      }, (data) => {
+        return true;
       });
       alert(JSON.stringify(data));
     } catch (e) {
-      alert(e);
+      if (e.name === "WriteGuardBeforeCheckError") {
+        console.log("WriteGuardBeforeCheckError.data", JSON.stringify(e.data));
+      } else if (e.name === "WriteGuardAfterCheckError") {
+        console.log("WriteGuardAfterCheckError.data", JSON.stringify(e.data));
+      }
+      alert(e.message || e);
     }
   }
 

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -63,7 +63,7 @@ export class HelloWorldModel extends observable.Observable {
       }
     }, {
       stopAfterFirstRead: true,
-      scanHint: "Scan a tag, baby!"
+      startMessage: "Scan a tag, baby!"
     })
         .then(() => this.set("lastNdefDiscovered", "Listening..."))
         .catch(err => alert(err));
@@ -83,9 +83,11 @@ export class HelloWorldModel extends observable.Observable {
         textRecords: [
           {
             id: [1],
-            text: "Hello!!!!!"
-          }
-        ]
+            text: "Hello!!!!!",
+          },
+        ],
+        startMessage: "Hold near writable NFC tag to write.",
+        endMessage: "Command sent!",
       });
       alert(JSON.stringify(data));
     } catch (e) {

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -34,6 +34,17 @@
         "semver": "6.3.0",
         "tns-core-modules-widgets": "^6.5.10",
         "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "nativescript-hook": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.5.tgz",
+          "integrity": "sha512-ciGJtNbtMB2lGv8jAkUripkRjd3g8atX9VYPSt6e8PI6YPiOKeoma3xjcXoW66pFMYpHnfrbp6Mq9U/QtiQrVg==",
+          "requires": {
+            "glob": "^6.0.1",
+            "mkdirp": "^0.5.1"
+          }
+        }
       }
     },
     "@nordsense/nativescript-nfc": {
@@ -71,7 +82,6 @@
             "nativescript-hook": "0.2.5",
             "reduce-css-calc": "^2.1.6",
             "semver": "6.3.0",
-            "tns-core-modules-widgets": "^6.5.10",
             "tslib": "1.10.0"
           }
         },
@@ -857,9 +867,9 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -1347,9 +1357,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "buffer-xor": {
@@ -1392,9 +1402,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1809,9 +1819,9 @@
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "create-ecdh": {
@@ -2423,9 +2433,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -2553,12 +2563,12 @@
       }
     },
     "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "dev": true,
       "requires": {
-        "type": "^2.0.0"
+        "type": "^2.5.0"
       },
       "dependencies": {
         "type": {
@@ -2756,9 +2766,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
       "dev": true
     },
     "for-in": {
@@ -2847,9 +2857,9 @@
       }
     },
     "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
     },
     "fqueue": {
@@ -3042,9 +3052,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3058,9 +3068,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
     "gzip-size": {
@@ -3532,9 +3542,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -3717,9 +3727,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3742,9 +3752,9 @@
       },
       "dependencies": {
         "jasmine-core": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.7.1.tgz",
-          "integrity": "sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
+          "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==",
           "dev": true
         }
       }
@@ -3897,9 +3907,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -4161,24 +4171,24 @@
       }
     },
     "mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true
     },
     "mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
       "dev": true,
       "requires": {
-        "mime-db": "1.47.0"
+        "mime-db": "1.50.0"
       }
     },
     "mimic-fn": {
@@ -4298,9 +4308,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
       "dev": true,
       "optional": true
     },
@@ -4427,16 +4437,6 @@
         "webpack-sources": "~1.3.0"
       },
       "dependencies": {
-        "nativescript-hook": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.4.tgz",
-          "integrity": "sha1-5ZHh2a1BWotPMwnBVzFXevRKPdQ=",
-          "dev": true,
-          "requires": {
-            "glob": "^6.0.1",
-            "mkdirp": "^0.5.1"
-          }
-        },
         "shelljs": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
@@ -4446,9 +4446,9 @@
       }
     },
     "nativescript-hook": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.5.tgz",
-      "integrity": "sha512-ciGJtNbtMB2lGv8jAkUripkRjd3g8atX9VYPSt6e8PI6YPiOKeoma3xjcXoW66pFMYpHnfrbp6Mq9U/QtiQrVg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.4.tgz",
+      "integrity": "sha1-5ZHh2a1BWotPMwnBVzFXevRKPdQ=",
       "requires": {
         "glob": "^6.0.1",
         "mkdirp": "^0.5.1"
@@ -4465,17 +4465,6 @@
       "integrity": "sha512-ZBCxVcnoRicCmHWjP0eGDo7hNmSSmhlyzvtSvM12MYS4md13vnKIY/DX4K4dkTcEAFTCjz5atyS9W9tq4II35g==",
       "requires": {
         "nativescript-hook": "0.2.4"
-      },
-      "dependencies": {
-        "nativescript-hook": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.4.tgz",
-          "integrity": "sha1-5ZHh2a1BWotPMwnBVzFXevRKPdQ=",
-          "requires": {
-            "glob": "^6.0.1",
-            "mkdirp": "^0.5.1"
-          }
-        }
       }
     },
     "nativescript-worker-loader": {
@@ -4932,10 +4921,16 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
     "picomatch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true,
       "optional": true
     },
@@ -4961,56 +4956,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       }
     },
     "postcss-modules-extract-imports": {
@@ -5096,12 +5048,12 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
     },
@@ -5567,9 +5519,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5808,9 +5760,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
     },
     "slash": {
@@ -6038,9 +5990,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -6341,9 +6293,9 @@
           }
         },
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -6997,6 +6949,14 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        }
       }
     },
     "vm-browserify": {
@@ -7052,20 +7012,20 @@
           }
         },
         "chokidar": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "anymatch": "~3.1.1",
+            "anymatch": "~3.1.2",
             "braces": "~3.0.2",
-            "fsevents": "~2.3.1",
-            "glob-parent": "~5.1.0",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.5.0"
+            "readdirp": "~3.6.0"
           }
         },
         "fill-range": {
@@ -7113,9 +7073,9 @@
           "optional": true
         },
         "readdirp": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7241,9 +7201,9 @@
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"

--- a/src/nfc.android.ts
+++ b/src/nfc.android.ts
@@ -1,5 +1,5 @@
 import {
-  NdefListenerOptions,
+  NDEFListenerOptions,
   NfcApi,
   NfcNdefData,
   NfcNdefRecord,
@@ -326,14 +326,14 @@ export class Nfc implements NfcApi {
     });
   }
 
-  public setOnTagDiscoveredListener(callback: (data: NfcTagData) => void): Promise<any> {
+  public setOnTagDiscoveredListener(callback: (data: NfcTagData) => void): Promise<void> {
     return new Promise((resolve, reject) => {
       onTagDiscoveredListener = callback;
       resolve();
     });
   }
 
-  public setOnNdefDiscoveredListener(callback: (data: NfcNdefData) => void, options?: NdefListenerOptions): Promise<any> {
+  public setOnNdefDiscoveredListener(callback: (data: NfcNdefData) => void, options?: NDEFListenerOptions): Promise<void> {
     return new Promise((resolve, reject) => {
       // TODO use options, some day
       onNdefDiscoveredListener = callback;
@@ -341,7 +341,7 @@ export class Nfc implements NfcApi {
     });
   }
 
-  public eraseTag(): Promise<any> {
+  public eraseTag(): Promise<void> {
     return new Promise((resolve, reject) => {
       const intent = application.android.foregroundActivity.getIntent() || nfcIntentHandler.savedIntent;
       if (!intent) {

--- a/src/nfc.common.ts
+++ b/src/nfc.common.ts
@@ -49,9 +49,9 @@ export interface NFCNDEFReaderSessionOptions {
    */
   startMessage?: string;
   endMessage?: string;
-  writeGuardErrorMessage?: string;
-  readAfterWriteDelay?: number;
-  readAfterWriteErrorMessage?: string;
+  writeGuardBeforeCheckErrorMessage?: string;
+  writeGuardAfterCheckErrorMessage?: string;
+  writeGuardAfterCheckDelay?: number;
 }
 
 export interface NDEFListenerOptions extends NFCNDEFReaderSessionOptions {}
@@ -136,8 +136,8 @@ export interface NfcApi {
   enabled(): Promise<boolean>;
   writeTag(
     options: WriteTagOptions,
-    writeGuardCallback?: (data: NfcNdefData) => boolean,
-    readAfterWriteCheckCallback?: (data: NfcNdefData) => boolean
+    writeGuardBeforeCheckCallback?: (data: NfcNdefData) => boolean,
+    writeGuardAfterCheckCallback?: (data: NfcNdefData) => boolean
   ): Promise<NfcNdefData>;
   eraseTag(): Promise<void>;
   /**
@@ -184,27 +184,27 @@ export class Nfc implements NfcApi {
 
   writeTag(
     options: WriteTagOptions,
-    writeGuardCallback?: (data: NfcNdefData) => boolean,
-    readAfterWriteCheckCallback?: (data: NfcNdefData) => boolean
+    writeGuardBeforeCheckCallback?: (data: NfcNdefData) => boolean,
+    writeGuardAfterCheckCallback?: (data: NfcNdefData) => boolean
   ): Promise<NfcNdefData> {
     return undefined;
   }
 }
 
-export class WriteGuardError extends Error {
+export class WriteGuardBeforeCheckError extends Error {
   data: NfcNdefData;
   constructor(message, data: NfcNdefData) {
     super(message);
-    this.name = "WriteGuardError";
+    this.name = "WriteGuardBeforeCheckError";
     this.data = data;
   }
 }
 
-export class ReadAfterWriteError extends Error {
+export class WriteGuardAfterCheckError extends Error {
   data: NfcNdefData;
   constructor(message, data: NfcNdefData) {
     super(message);
-    this.name = "ReadAfterWriteError";
+    this.name = "WriteGuardAfterCheckError";
     this.data = data;
   }
 }

--- a/src/nfc.common.ts
+++ b/src/nfc.common.ts
@@ -49,6 +49,9 @@ export interface NFCNDEFReaderSessionOptions {
    */
   startMessage?: string;
   endMessage?: string;
+  writeGuardErrorMessage?: string;
+  readAfterWriteDelay?: number;
+  readAfterWriteErrorMessage?: string;
 }
 
 export interface NDEFListenerOptions extends NFCNDEFReaderSessionOptions {}
@@ -83,9 +86,6 @@ export interface UriRecord {
 export interface WriteTagOptions extends NFCNDEFReaderSessionOptions {
   textRecords?: Array<TextRecord>;
   uriRecords?: Array<UriRecord>;
-  writeGuardMessage?: string;
-  retryInterval?: number;
-
 }
 
 export interface NfcTagData {
@@ -136,7 +136,8 @@ export interface NfcApi {
   enabled(): Promise<boolean>;
   writeTag(
     options: WriteTagOptions,
-    writeGuardCallback?: (data: NfcNdefData) => boolean
+    writeGuardCallback?: (data: NfcNdefData) => boolean,
+    readAfterWriteCheckCallback?: (data: NfcNdefData) => boolean
   ): Promise<NfcNdefData>;
   eraseTag(): Promise<void>;
   /**
@@ -183,7 +184,8 @@ export class Nfc implements NfcApi {
 
   writeTag(
     options: WriteTagOptions,
-    writeGuardCallback?: (data: NfcNdefData) => boolean
+    writeGuardCallback?: (data: NfcNdefData) => boolean,
+    readAfterWriteCheckCallback?: (data: NfcNdefData) => boolean
   ): Promise<NfcNdefData> {
     return undefined;
   }
@@ -196,4 +198,13 @@ export class WriteGuardError extends Error {
     this.name = "WriteGuardError";
     this.data = data;
   }
-} 
+}
+
+export class ReadAfterWriteError extends Error {
+  data: NfcNdefData;
+  constructor(message, data: NfcNdefData) {
+    super(message);
+    this.name = "ReadAfterWriteError";
+    this.data = data;
+  }
+}

--- a/src/nfc.common.ts
+++ b/src/nfc.common.ts
@@ -51,6 +51,7 @@ export interface NFCNDEFReaderSessionOptions {
   endMessage?: string;
   writeGuardBeforeCheckErrorMessage?: string;
   writeGuardAfterCheckErrorMessage?: string;
+  writeGuardAfterCheckMessage?: string;
   writeGuardAfterCheckDelay?: number;
 }
 

--- a/src/nfc.common.ts
+++ b/src/nfc.common.ts
@@ -193,6 +193,7 @@ export class WriteGuardError extends Error {
   data: NfcNdefData;
   constructor(message, data: NfcNdefData) {
     super(message);
+    this.name = "WriteGuardError";
     this.data = data;
   }
 } 

--- a/src/nfc.common.ts
+++ b/src/nfc.common.ts
@@ -1,6 +1,43 @@
-export const NfcUriProtocols = ["", "http://www.", "https://www.", "http://", "https://", "tel:", "mailto:", "ftp://anonymous:anonymous@", "ftp://ftp.", "ftps://", "sftp://", "smb://", "nfs://", "ftp://", "dav://", "news:", "telnet://", "imap:", "rtsp://", "urn:", "pop:", "sip:", "sips:", "tftp:", "btspp://", "btl2cap://", "btgoep://", "tcpobex://", "irdaobex://", "file://", "urn:epc:id:", "urn:epc:tag:", "urn:epc:pat:", "urn:epc:raw:", "urn:epc:", "urn:nfc:"];
+export const NfcUriProtocols = [
+  "",
+  "http://www.",
+  "https://www.",
+  "http://",
+  "https://",
+  "tel:",
+  "mailto:",
+  "ftp://anonymous:anonymous@",
+  "ftp://ftp.",
+  "ftps://",
+  "sftp://",
+  "smb://",
+  "nfs://",
+  "ftp://",
+  "dav://",
+  "news:",
+  "telnet://",
+  "imap:",
+  "rtsp://",
+  "urn:",
+  "pop:",
+  "sip:",
+  "sips:",
+  "tftp:",
+  "btspp://",
+  "btl2cap://",
+  "btgoep://",
+  "tcpobex://",
+  "irdaobex://",
+  "file://",
+  "urn:epc:id:",
+  "urn:epc:tag:",
+  "urn:epc:pat:",
+  "urn:epc:raw:",
+  "urn:epc:",
+  "urn:nfc:",
+];
 
-export interface NdefListenerOptions {
+export interface NFCNDEFReaderSessionOptions {
   /**
    * iOS only (for now).
    * Default false.
@@ -10,9 +47,11 @@ export interface NdefListenerOptions {
    * On iOS the scan UI can show a scan hint (fi. "Scan a tag").
    * By default no hint is shown.
    */
-  scanHint?: string;
-  writeHint?: string;
+  startMessage?: string;
+  endMessage?: string;
 }
+
+export interface NDEFListenerOptions extends NFCNDEFReaderSessionOptions {}
 
 export interface TextRecord {
   /**
@@ -41,7 +80,7 @@ export interface UriRecord {
   id?: Array<number>;
 }
 
-export interface WriteTagOptions {
+export interface WriteTagOptions extends NFCNDEFReaderSessionOptions {
   textRecords?: Array<TextRecord>;
   uriRecords?: Array<UriRecord>;
 }
@@ -92,21 +131,21 @@ export interface OnTagDiscoveredOptions {
 export interface NfcApi {
   available(): Promise<boolean>;
   enabled(): Promise<boolean>;
-  writeTag(arg: WriteTagOptions): Promise<NfcNdefData>;
-  eraseTag(): Promise<any>;
+  writeTag(options: WriteTagOptions): Promise<NfcNdefData>;
+  eraseTag(): Promise<void>;
   /**
    * Set to null to remove the listener.
    */
   setOnTagDiscoveredListener(
     callback: (data: NfcTagData) => void
-  ): Promise<any>;
+  ): Promise<void>;
   /**
    * Set to null to remove the listener.
    */
   setOnNdefDiscoveredListener(
     callback: (data: NfcNdefData) => void,
-    options?: NdefListenerOptions
-  ): Promise<any>;
+    options?: NDEFListenerOptions
+  ): Promise<void>;
 }
 
 // this was done to generate a nice API for our users
@@ -119,24 +158,24 @@ export class Nfc implements NfcApi {
     return undefined;
   }
 
-  eraseTag(): Promise<any> {
+  eraseTag(): Promise<void> {
     return undefined;
   }
 
   setOnNdefDiscoveredListener(
     callback: (data: NfcNdefData) => void,
-    options?: NdefListenerOptions
-  ): Promise<any> {
+    options?: NDEFListenerOptions
+  ): Promise<void> {
     return undefined;
   }
 
   setOnTagDiscoveredListener(
     callback: (data: NfcTagData) => void
-  ): Promise<any> {
+  ): Promise<void> {
     return undefined;
   }
 
-  writeTag(arg: WriteTagOptions): Promise<NfcNdefData> {
+  writeTag(options: WriteTagOptions): Promise<NfcNdefData> {
     return undefined;
   }
 }

--- a/src/nfc.common.ts
+++ b/src/nfc.common.ts
@@ -83,6 +83,9 @@ export interface UriRecord {
 export interface WriteTagOptions extends NFCNDEFReaderSessionOptions {
   textRecords?: Array<TextRecord>;
   uriRecords?: Array<UriRecord>;
+  writeGuardMessage?: string;
+  retryInterval?: number;
+
 }
 
 export interface NfcTagData {
@@ -131,7 +134,10 @@ export interface OnTagDiscoveredOptions {
 export interface NfcApi {
   available(): Promise<boolean>;
   enabled(): Promise<boolean>;
-  writeTag(options: WriteTagOptions): Promise<NfcNdefData>;
+  writeTag(
+    options: WriteTagOptions,
+    writeGuardCallback?: (data: NfcNdefData) => boolean
+  ): Promise<NfcNdefData>;
   eraseTag(): Promise<void>;
   /**
    * Set to null to remove the listener.
@@ -175,7 +181,18 @@ export class Nfc implements NfcApi {
     return undefined;
   }
 
-  writeTag(options: WriteTagOptions): Promise<NfcNdefData> {
+  writeTag(
+    options: WriteTagOptions,
+    writeGuardCallback?: (data: NfcNdefData) => boolean
+  ): Promise<NfcNdefData> {
     return undefined;
   }
 }
+
+export class WriteGuardError extends Error {
+  data: NfcNdefData;
+  constructor(message, data: NfcNdefData) {
+    super(message);
+    this.data = data;
+  }
+} 

--- a/src/nfc.ios.ts
+++ b/src/nfc.ios.ts
@@ -476,6 +476,10 @@ class NFCNDEFReaderSessionDelegateWriteImpl
                                   "Erased data from NFC tag.";
                               } else {
                                 this.writeGuardAfterCheck = true;
+                                if (this.options.writeGuardAfterCheckMessage) {
+                                  session.alertMessage =
+                                    this.options.writeGuardAfterCheckMessage;
+                                }
                                 utils.executeOnMainThread(() =>
                                   setTimeout(
                                     () => session.restartPolling(),

--- a/src/nfc.ios.ts
+++ b/src/nfc.ios.ts
@@ -331,35 +331,7 @@ class NFCNDEFReaderSessionDelegateWriteImpl
     const prototype = NFCNDEFTag.prototype;
     const tag = (<NSArray<NFCNDEFTag>>tags).firstObject;
     console.log("Pooling", this.pooling);
-    
-    
-    if (this.pooling) {
-      // Read back the data
-      prototype.readNDEFWithCompletionHandler.call(
-        tag,
-        (message: NFCNDEFMessage, error: NSError) => {
-          console.log("readNDEFWithCompletionHandler");
-          if (error) {
-            console.log(error);
-            session.invalidateSessionWithErrorMessage(
-              "Error reading NDEF message from tag."
-            );
-            this.errorCallback(error);
-            return;
-          }
-          const data = NfcHelper.ndefToJson(message);
-          console.log("Read back message", JSON.stringify(data));
 
-          if (this.options.endMessage) {
-            session.alertMessage = this.options.endMessage;
-          }
-          this.resultCallback(data);
-          session.invalidateSession();
-          return;
-        }
-      );
-      return;
-    }
     //session.restartPolling();
     // utils.executeOnMainThread(() =>
     //   setTimeout(() => session.connectToTagCompletionHandler(tag, (error: NSError) => {
@@ -383,7 +355,33 @@ class NFCNDEFReaderSessionDelegateWriteImpl
       //   tag
       // ).value;
 
-      
+      if (this.pooling) {
+        // Read back the data
+        prototype.readNDEFWithCompletionHandler.call(
+          tag,
+          (message: NFCNDEFMessage, error: NSError) => {
+            console.log("readNDEFWithCompletionHandler");
+            if (error) {
+              console.log(error);
+              session.invalidateSessionWithErrorMessage(
+                "Error reading NDEF message from tag."
+              );
+              this.errorCallback(error);
+              return;
+            }
+            const data = NfcHelper.ndefToJson(message);
+            console.log("Read back message", JSON.stringify(data));
+
+            if (this.options.endMessage) {
+              session.alertMessage = this.options.endMessage;
+            }
+            this.resultCallback(data);
+            session.invalidateSession();
+            return;
+          }
+        );
+        return;
+      }
 
       try {
         prototype.queryNDEFStatusWithCompletionHandler.call(
@@ -447,7 +445,7 @@ class NFCNDEFReaderSessionDelegateWriteImpl
                       prototype.writeNDEFCompletionHandler.call(
                         tag,
                         ndefMessage,
-                        async (error: NSError) => {
+                        (error: NSError) => {
                           console.log("writeNDEFCompletionHandler");
                           if (error) {
                             console.log(error);

--- a/src/nfc.ios.ts
+++ b/src/nfc.ios.ts
@@ -10,7 +10,7 @@ import {
   TextRecord,
   NFCNDEFReaderSessionOptions,
   WriteGuardBeforeCheckError,
-  WriteGuardAfterCheckError
+  WriteGuardAfterCheckError,
 } from "./nfc.common";
 
 export { WriteGuardBeforeCheckError, WriteGuardAfterCheckError };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordsense/nativescript-nfc",
-  "version": "4.2.2",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nordsense/nativescript-nfc",
-  "version": "4.2.2",
+  "version": "4.4.0",
   "description": "NFC plugin for your NativeScript app",
   "main": "nfc",
   "typings": "index.d.ts",
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "npm i && tsc --skipLibCheck",
-    "demo.ios": "npm run build && cd ../demo && tns run ios",
+    "demo.ios": "npm run build && cd ../demo && tns run ios --device 00008030-00114D3C3E42802E",
     "demo.ios.bundle": "npm run build && cd ../demo && tns run ios --bundle",
     "demo.android": "npm run build && cd ../demo && tns run android",
     "demo.android.bundle": "npm run build && cd ../demo && tns run android --bundle",


### PR DESCRIPTION
Two guards are added:
1. `writeGuardBeforeCheckCallback`: will be triggered before writing NFC command to the sensor
2. `writeGuardAfterCheckCallback`: will be triggered after successfully writing NFC command to the sensor

Use `writeGuardAfterCheckDelay` to control when to read data back from sensor after a successful write.
Use `writeGuardBeforeCheckErrorMessage` and `writeGuardAfterCheckErrorMessage` to set the error messages when write guard check fails
Use `writeGuardAfterCheckMessage` to show instruction to users before the final check after write.

It also supports removing and approaching tag again to finish the final check in the same session.
